### PR TITLE
adjust metadata.yaml to be in line with charm best practices

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020 Balbir Thomas
 # Copyright 2020 Justin M Clark
 # See LICENSE file for licensing details.
-name: elasticsearch-operator
+name: elasticsearch
 maintainers:
     - Balbir Thomas <balbir.thomas@canonical.com>
     - Justin M Clark <justin.clark@canonical.com>
@@ -9,13 +9,14 @@ description: |
   Elasticsearch is the distributed search and analytics engine.
 summary: |
   A distributed search and analytics solution.
-series: [kubernetes]
+series:
+    - kubernetes
 peers:
   elasticsearch:
     interface: elasticsearch
 provides:
   datastore:
-    interface: es-datastore
+    interface: elasticsearch-datastore
 storage:
   data:
     type: filesystem


### PR DESCRIPTION
1) change the name from elasticsearch-operator to elasticsearch
2) change format of the 'series' tag
3) change interface name of datastore from es-datastore to elasticsearch-datastore

We discussed that interface names should be {name}-{service} in previous charm reviews.